### PR TITLE
Remove unused fasmg-ez80 module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "src/deps/fasmg-ez80"]
-	path = src/deps/fasmg-ez80
-	url = https://github.com/jacobly0/fasmg-ez80.git
 [submodule "src/deps/libimagequant"]
 	path = src/deps/libimagequant
 	url = https://github.com/mateoconlechuga/libimagequant.git


### PR DESCRIPTION
After fixing CE-Programming/toolchain#498, I ran into the same issue here. I built the program to make sure it worked, and it worked just fine.