### PR TITLE
Removed K&R prototypes from glob

### DIFF
--- a/src/deps/glob/fnmatch.c
+++ b/src/deps/glob/fnmatch.c
@@ -121,7 +121,7 @@ USA.  */
    whose names are inconsistent.  */
 
 # if !defined _LIBC && !defined getenv
-extern char *getenv ();
+extern char *getenv (const char*);
 # endif
 
 # ifndef errno
@@ -132,10 +132,10 @@ extern int errno;
 
 # if !defined HAVE___STRCHRNUL && !defined _LIBC
 static char *
-__strchrnul (s, c)
-     const char *s;
-     int c;
-{
+__strchrnul (
+     const char *s,
+     int c
+) {
   char *result = strchr (s, c);
   if (result == NULL)
     result = strchr (s, '\0');
@@ -156,12 +156,12 @@ static int internal_fnmatch __P ((const char *pattern, const char *string,
      internal_function;
 static int
 internal_function
-internal_fnmatch (pattern, string, no_leading_period, flags)
-     const char *pattern;
-     const char *string;
-     int no_leading_period;
-     int flags;
-{
+internal_fnmatch (
+     const char *pattern,
+     const char *string,
+     int no_leading_period,
+     int flags
+) {
   register const char *p = pattern, *n = string;
   register unsigned char c;
 
@@ -478,11 +478,11 @@ internal_fnmatch (pattern, string, no_leading_period, flags)
 
 
 int
-fnmatch (pattern, string, flags)
-     const char *pattern;
-     const char *string;
-     int flags;
-{
+fnmatch (
+     const char *pattern,
+     const char *string,
+     int flags
+) {
   return internal_fnmatch (pattern, string, flags & FNM_PERIOD, flags);
 }
 

--- a/src/deps/glob/glob.c
+++ b/src/deps/glob/glob.c
@@ -288,7 +288,7 @@ extern int getlogin_r __P ((char *, size_t));
 #else
 extern char *getlogin __P ((void));
 #endif
-
+
 static
 #if __GNUC__ - 0 >= 2
 inline
@@ -312,9 +312,9 @@ static
 inline
 #endif
 const char *
-next_brace_sub (begin)
-     const char *begin;
-{
+next_brace_sub (
+     const char *begin
+) {
   unsigned int depth = 0;
   const char *cp = begin;
 
@@ -359,12 +359,12 @@ next_brace_sub (begin)
    If memory cannot be allocated for PGLOB, GLOB_NOSPACE is returned.
    Otherwise, `glob' returns zero.  */
 int
-glob (pattern, flags, errfunc, pglob)
-     const char *pattern;
-     int flags;
-     int (*errfunc) __P ((const char *, int));
-     glob_t *pglob;
-{
+glob (
+     const char *pattern,
+     int flags,
+     int (*errfunc) __P ((const char *, int)),
+     glob_t *pglob
+) {
   const char *filename;
   const char *dirname;
   size_t dirlen;
@@ -1067,9 +1067,9 @@ glob (pattern, flags, errfunc, pglob)
 
 /* Free storage allocated in PGLOB by a previous `glob' call.  */
 void
-globfree (pglob)
-     register glob_t *pglob;
-{
+globfree (
+     register glob_t *pglob
+) {
   if (pglob->gl_pathv != NULL)
     {
       register int i;
@@ -1083,10 +1083,10 @@ globfree (pglob)
 
 /* Do a collated comparison of A and B.  */
 static int
-collated_compare (a, b)
-     const __ptr_t a;
-     const __ptr_t b;
-{
+collated_compare (
+     const __ptr_t a,
+     const __ptr_t b
+) {
   const char *const s1 = *(const char *const * const) a;
   const char *const s2 = *(const char *const * const) b;
 
@@ -1105,11 +1105,11 @@ collated_compare (a, b)
    A slash is inserted between DIRNAME and each elt of ARRAY,
    unless DIRNAME is just "/".  Each old element of ARRAY is freed.  */
 static int
-prefix_array (dirname, array, n)
-     const char *dirname;
-     char **array;
-     size_t n;
-{
+prefix_array (
+     const char *dirname,
+     char **array,
+     size_t n
+) {
   register size_t i;
   size_t dirlen = strlen (dirname);
 #if defined __MSDOS__ || defined WINDOWS32
@@ -1173,10 +1173,10 @@ prefix_array (dirname, array, n)
 /* Return nonzero if PATTERN contains any metacharacters.
    Metacharacters can be quoted with backslashes if QUOTE is nonzero.  */
 int
-__glob_pattern_p (pattern, quote)
-     const char *pattern;
-     int quote;
-{
+__glob_pattern_p (
+     const char *pattern,
+     int quote
+) {
   register const char *p;
   int open = 0;
 
@@ -1215,13 +1215,13 @@ weak_alias (__glob_pattern_p, glob_pattern_p)
    The GLOB_NOSORT bit in FLAGS is ignored.  No sorting is ever done.
    The GLOB_APPEND flag is assumed to be set (always appends).  */
 static int
-glob_in_dir (pattern, directory, flags, errfunc, pglob)
-     const char *pattern;
-     const char *directory;
-     int flags;
-     int (*errfunc) __P ((const char *, int));
-     glob_t *pglob;
-{
+glob_in_dir (
+     const char *pattern,
+     const char *directory,
+     int flags,
+     int (*errfunc) __P ((const char *, int)),
+     glob_t *pglob
+) {
   __ptr_t stream = NULL;
 
   struct globlink


### PR DESCRIPTION
Removed K&R prototypes `char *getenv()` (deprecated since C89, removed in C23) and replaced them with standard C prototypes `char *getenv(const char*)`. This also fixes the `getenv` conflicts when compiling on Windows.