### PR TITLE
Output image define for appvar as a const lvalue

### DIFF
--- a/src/output-appvar.c
+++ b/src/output-appvar.c
@@ -420,7 +420,7 @@ static void output_appvar_c_include_file_converts(struct output *output, FILE *f
 
                 if (image->gfx)
                 {
-                    fprintf(fdh, "#define %s ((%s*)%s_appvar[%u])\n",
+                    fprintf(fdh, "#define %s (*(%s* const*)&%s_appvar[%u])\n",
                         image->name,
                         image->rlet ? "gfx_rletsprite_t" : "gfx_sprite_t",
                         output->appvar.name,


### PR DESCRIPTION
In the current setup, it would not be possible to reference to the address of a defined image, i.e. `&image`, since it is an rvalue. Change the output to be an lvalue, such that using the address in the table is possible. Some reference discussion:

--------------

PT_: Quick question for the C nerds out here (and I'm a bit ashamed to ask this lol): is there a proper way to refer to images, spitted out by convimg and put in an appvar, within a constant array? I.e. I have the images `image1`, `image2` etc, which are defined as `((gfx_rletsprite_t*)appvar[index]` (and initialized, i.e. the proper pointers are stored in the array), and I want to have a constant array of `image1` and `image2` (or rather, pointers to it)? Something like `gfx_rletsprite_t *test[2] = {image1, image2}` doesn't work, and `&image1` is logically not valid as well. Don't be too harsh on me heh

PT_: And writing `&image1` is easier than writing `(gfx_rletsprite_t**)&appvar[appvar_index]` 😛

calc84maniac : so are you thinking a feature suggestion for convimg to change the primary image macros to be something like `*(gfx_rletsprite_t* const*)&appvar[appvar_index]`

calc84maniac: the way I rewrote it there basically changes it into a const lvalue instead of an rvalue, so its address can be taken but it can't be assigned to

--------------

This PR doesn't break existing code, as displaying images with `gfx_RLETSprite(image,...)` still works as intended. All the example from the toolchain compile normally.

Also, if more lines need to change I'm open for that!