### PR TITLE
use -msse2 to ensure double is consistent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ ifeq ($(OS),Windows_NT)
 
   # if windows check for arm processor (should hopefully work?)
   ifneq ($(PROCESSOR_ARCHITECTURE),ARM64)
-    CFLAGS_LIQ += -DUSE_SSE=1 -msse -mfpmath=sse
+    CFLAGS_LIQ += -DUSE_SSE=1 -msse2 -mfpmath=sse
   endif
 
   # build windows binaries statically linked
@@ -124,10 +124,10 @@ else
 
   # check for x86 support
   ifeq ($(shell uname -p),x86_64)
-    CFLAGS_LIQ += -DUSE_SSE=1 -msse -mfpmath=sse
+    CFLAGS_LIQ += -DUSE_SSE=1 -msse2 -mfpmath=sse
   else
     ifneq ($(filter %86,$(shell uname -p)),)
-      CFLAGS_LIQ += -DUSE_SSE=1 -msse -mfpmath=sse
+      CFLAGS_LIQ += -DUSE_SSE=1 -msse2 -mfpmath=sse
     endif
   endif
 


### PR DESCRIPTION
TL:DR `-msse` should be replaced with `-msse2` to avoid rounding issues with `double`. This breaks compatibility with 32bit CPU's made before 2001.

`-msse` only provides native `float` operations. Without `-msse2`, `double` operations would go through the x87 FPU which uses `long double`. This creates rounding inconsistencies between targets that use native `double` and `double` rounded from the x87 FPU. All 64bit AMD64/x86-64 CPU's support `-msse2`, and basically all 32 bit CPU's made after 2001 support `-msse2`, and 32bit Windows 8 requires `-msse2` anyways. I think compiling for `x86-64` may already imply `-msse2`, but it doesn't hurt to be explicit.
